### PR TITLE
forgot to add 150 вишневый сок to English translation

### DIFF
--- a/cocktails_for_programers.md
+++ b/cocktails_for_programers.md
@@ -25,6 +25,7 @@ PS: [Great comments on Reddit](http://www.reddit.com/r/programming/comments/1m6n
 - 20 mL Malibu (coconut liqueur)
 - 20 mL Lychee Liqueur (a fruit)
 - 40 mL Cognac or Brandy
+- 150 mL Cherry juice
 - Lemon
 - Ice
 ```


### PR DESCRIPTION
The Russian translation includes `150 вишневый сок` in the ingredient list for Ruby drink. The English translation doesn't.
